### PR TITLE
Pin freetype (Pt. 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Terminology
 
 Current build status
 ====================
+
 Linux: [![Circle CI](https://circleci.com/gh/conda-forge/cairo-feedstock.svg?style=svg)](https://circleci.com/gh/conda-forge/cairo-feedstock)
 OSX: [![TravisCI](https://travis-ci.org/conda-forge/cairo-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/cairo-feedstock) 
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/cairo-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/cairo-feedstock/branch/master)

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -29,7 +29,7 @@ cat << EOF | docker run -i \
                         -v ${RECIPE_ROOT}:/recipe_root \
                         -v ${FEEDSTOCK_ROOT}:/feedstock_root \
                         -a stdin -a stdout -a stderr \
-                        pelson/obvious-ci:latest_x64 \
+                        condaforge/linux-anvil \
                         bash || exit $?
 
 export BINSTAR_TOKEN=${BINSTAR_TOKEN}
@@ -40,7 +40,7 @@ echo "$config" > ~/.condarc
 conda clean --lock
 
 conda update --yes --all
-conda install --yes conda-build==1.18.2
+conda install --yes conda-build
 conda info
 
 # Embarking on 1 case(s).

--- a/circle.yml
+++ b/circle.yml
@@ -6,8 +6,7 @@ dependencies:
   # Note, we used to use the naive caching of docker images, but found that it was quicker
   # just to pull each time. #rollondockercaching
   override:
-    - docker pull pelson/obvious-ci:latest_x64
-#    - docker pull pelson/conda32_obvious_ci
+    - docker pull condaforge/linux-anvil
 
 test:
   override:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - fontconfig 2.11.*       # [unix]
     - pixman                  # [unix]
     - libpng 1.6*
+    - libxml2 2.9.3
     - zlib 1.2*
     - icu 56.*
   run:
@@ -34,6 +35,7 @@ requirements:
     - fontconfig 2.11.*       # [unix]
     - libpng 1.6*
     - pixman                  # [unix]
+    - libxml2 2.9.3
     - zlib 1.2*
     - icu 56.*
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,12 +22,11 @@ requirements:
     - python                  # [win]
     - pkg-config              # [unix]
     - libtool                 # [unix]
-    - xz                      # [unix]
+    - xz 5.0.*                # [unix]
     - freetype 2.6*           # [unix]
     - fontconfig 2.11.*       # [unix]
     - pixman                  # [unix]
     - libpng 1.6*
-    - libxml2 2.9.3
     - zlib 1.2*
     - icu 56.*
   run:
@@ -35,7 +34,6 @@ requirements:
     - fontconfig 2.11.*       # [unix]
     - libpng 1.6*
     - pixman                  # [unix]
-    - libxml2 2.9.3
     - zlib 1.2*
     - icu 56.*
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
   build:
     - python                  # [win]
     - pkg-config              # [unix]
+    - libtool                 # [unix]
     - xz                      # [unix]
     - freetype 2.6*           # [unix]
     - fontconfig 2.11.*       # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,14 +22,14 @@ requirements:
     - python                  # [win]
     - pkg-config              # [unix]
     - xz                      # [unix]
-    - freetype 2.6*          # [unix]
+    - freetype 2.6*           # [unix]
     - fontconfig 2.11.*       # [unix]
     - pixman                  # [unix]
     - libpng 1.6*
     - zlib 1.2*
     - icu 56.*
   run:
-    - freetype 2.6*                # [unix]
+    - freetype 2.6*           # [unix]
     - fontconfig 2.11.*       # [unix]
     - libpng 1.6*
     - pixman                  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: 8e4ff32b82c3b39387eb6f5c59ef848e
 
 build:
-  number: 0
+  number: 1
   skip: true             # [win]
   features:
     - vc9                # [win and py27]
@@ -22,17 +22,19 @@ requirements:
     - python                  # [win]
     - pkg-config              # [unix]
     - xz                      # [unix]
-    - freetype 2.5.*          # [unix]
+    - freetype 2.6*          # [unix]
     - fontconfig 2.11.*       # [unix]
     - pixman                  # [unix]
     - libpng 1.6*
     - zlib 1.2*
+    - icu 56.*
   run:
-    - freetype                # [unix]
+    - freetype 2.6*                # [unix]
     - fontconfig 2.11.*       # [unix]
     - libpng 1.6*
     - pixman                  # [unix]
     - zlib 1.2*
+    - icu 56.*
 
 test:
   commands:


### PR DESCRIPTION
Based off of @ocefpaf's PR ( https://github.com/conda-forge/cairo-feedstock/pull/3 ). Also, merges in the re-rendering PR ( https://github.com/conda-forge/cairo-feedstock/pull/2 ).

This is a long and weird story where the main characters are the solver, `libxml2`, and `xz`.

The pinning proposed in the previous PR should be fine. Unfortunately, it fails due to what appears to be a bad libtool file as [seen]( https://travis-ci.org/conda-forge/cairo-feedstock/builds/132679481#L6781 ). Somehow something is not picking up the `libiconv` in the environment, but is picking up some other version (potentially from the system). Fortunately it failed here so we can identify this is wrong and fix it.

After some exploration locally, it turned out that the `libxml2` pulled in includes the system library path in its `libxml2.la` file instead of the prefix library path (now the problem begins). 📝 We can't use this `libxml2` obviously so we should upgrade. Well, the `defaults` version is 2.9.2, but ours is 2.9.3 so it should already be newer. We could try pinning the version of `libxml2` exactly. Sure enough that works. However, that is pretty fragile. I suppose we could add a lower bound, but that is a bit weird and could get us back in the same problem. 🎌 Blacklist might be a solution in the long term ( https://github.com/conda/conda/issues/2410 ). Though the real question is why is this happening. 💭

If one goes through the versions of everything pulled in here and in @ocefpaf's PR, only two packages will be seem to differ `libxml2` and `xz`. That's weird as we don't actually depend on `xz` except to decompress a file. However, as it is a build dependency and not something else like a pre-build dependency, a subenvironment package, or something similar, it will continue to affect the solve. So, what can we do aside from pinning `libxml2` in some fragile way. Well, it turns out that we do normally [pin]( https://github.com/conda-forge/staged-recipes/wiki/VC-features ) `xz` in our stack to `5.0.*`. ⚓ This actually works great as the reason we get only the newer `xz` and not the newer `libxml2` is that our `libxml2` pins `xz` as it should. As a result, the solver does what it should do. 🎉 Now I suppose this is weird as we don't link against `xz`. However, this is consistent across our stack and fixes the problem. If we run into more problems with this misbehaving `libxml2` package in `defaults` we can always bump the build number and/or version on ours to steer clear of troubled waters 🚢.