### PR TITLE
Bump build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: 8e4ff32b82c3b39387eb6f5c59ef848e
 
 build:
-  number: 2
+  number: 7
   skip: true             # [win]
   features:
     - vc9                # [win and py27]


### PR DESCRIPTION
The defaults channel version has the does not ship the static library. So we need to beat their build number to get conda-forge's version installed and get the static libs.