### PR TITLE
Update to upstream 1.14.12

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,7 +9,7 @@ if [ $(uname) == Darwin ]; then
     XWIN_ARGS="--disable-xlib --disable-xcb --disable-glitz"
 fi
 if [ $(uname) == Linux ]; then
-    XWIN_ARGS="--disable-xlib --disable-xlib-xrender --enable-xcb-shm"
+    XWIN_ARGS="--enable-xcb-shm"
 fi
 
 # Most other autotools-based build systems add

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.14.10" %}
+{% set version = "1.14.12" %}
 
 package:
   name: cairo
@@ -6,10 +6,10 @@ package:
 
 source:
   url: http://cairographics.org/releases/cairo-{{ version }}.tar.xz
-  sha256: 7e87878658f2c9951a14fc64114d4958c0e65ac47530b8ac3078b2ce41b66a09
+  sha256: 8c90f00c500b2299c0a323dd9beead2a00353752b2092ead558139bd67f7bf16
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:
@@ -31,6 +31,10 @@ requirements:
     - libpng
     - libxcb  # [linux]
     - pixman
+    - xorg-libice  # [linux]
+    - xorg-libsm  # [linux]
+    - xorg-libx11  # [linux]
+    - xorg-libxrender  # [linux]
     - zlib
   run:
     - freetype  # [not win]
@@ -40,6 +44,10 @@ requirements:
     - libpng
     - libxcb  # [linux]
     - pixman
+    - xorg-libice  # [linux]
+    - xorg-libsm  # [linux]
+    - xorg-libx11  # [linux]
+    - xorg-libxrender  # [linux]
     - zlib
 
 test:
@@ -64,6 +72,7 @@ test:
 about:
   home: http://cairographics.org/
   license: LGPL 2.1 or MPL 1.1
+  license_file: COPYING
   summary: 'Cairo is a 2D graphics library with support for multiple output devices.'
 
 extra:


### PR DESCRIPTION
Also add the license file and go back to providing the cairo-xlib backend on Linux, which is needed by
GTK+3.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
