### PR TITLE
Fix missing cairo GUI pkgconfig files

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,6 +67,10 @@ test:
     - test -f $PREFIX/lib/{{ each_cairo_lib }}.so     # [linux]
     {% endfor %}
 
+    # Check pkg-config files.
+    - test -f $PREFIX/lib/pkgconfig/cairo-quartz.pc   # [osx]
+    - test -f $PREFIX/lib/pkgconfig/cairo-xlib.pc     # [linux]
+
 about:
   home: http://cairographics.org/
   license: LGPL 2.1 or MPL 1.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 8c90f00c500b2299c0a323dd9beead2a00353752b2092ead558139bd67f7bf16
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,8 +66,6 @@ test:
     - test -f $PREFIX/lib/{{ each_cairo_lib }}.dylib  # [osx]
     - test -f $PREFIX/lib/{{ each_cairo_lib }}.so     # [linux]
     {% endfor %}
-    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
-    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
 
 about:
   home: http://cairographics.org/


### PR DESCRIPTION
Rebuild of `cairo` to get missing `pkgconfig` files needed on Linux and macOS. Required downstream for things like `gtk2`. ( https://github.com/conda-forge/gtk2-feedstock/pull/1 )

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes https://github.com/conda-forge/cairo-feedstock/issues/34

<!--
Please add any other relevant info below:
-->

Requires `fontconfig` packages built with PR ( https://github.com/conda-forge/fontconfig-feedstock/pull/25 ).