### PR TITLE
Stop packaging Libtool `.la` files.

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,6 +18,11 @@ export CFLAGS=${CFLAGS}" -I${PREFIX}/include"
 export CXXFLAGS=${CXXFLAGS}" -I${PREFIX}/include"
 export LDFLAGS=${LDFLAGS}" -L${PREFIX}/lib"
 
+# Cf. https://github.com/conda-forge/staged-recipes/issues/673, we're in the
+# process of excising Libtool files from our packages. Existing ones can break
+# the build while this happens.
+find $PREFIX -name '*.la' -delete
+
 ./configure \
     --prefix="${PREFIX}" \
     --enable-warnings \
@@ -33,3 +38,7 @@ make -j${CPU_COUNT}
 # Hangs for > 10 minutes on Linux
 #make check -j${CPU_COUNT}
 make install -j${CPU_COUNT}
+
+# Remove any new Libtool files we may have installed. It is intended that
+# conda-build will eventually do this automatically.
+find $PREFIX -name '*.la' -delete

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 8c90f00c500b2299c0a323dd9beead2a00353752b2092ead558139bd67f7bf16
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
Pursuant to https://github.com/conda-forge/staged-recipes/issues/673 and https://github.com/conda-forge/libxcb-feedstock/pull/9, we're going to remove these files from our packages. Eventually conda-build will do this automatically for us, but for now we take care of it manually. We need to delete the files both before the build (because inconsistent complements of `.la` files can break the build) and after (because we may have installed new ones).

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
