### PR TITLE
Upstream 1.16.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.14.12" %}
+{% set version = "1.16.0" %}
 
 package:
   name: cairo
@@ -6,10 +6,10 @@ package:
 
 source:
   url: http://cairographics.org/releases/cairo-{{ version }}.tar.xz
-  sha256: 8c90f00c500b2299c0a323dd9beead2a00353752b2092ead558139bd67f7bf16
+  sha256: 5e7b29b3f113ef870d1e3ecf8adf21f923396401604bda16d44be45e66052331
 
 build:
-  number: 1006
+  number: 1000
   run_exports:
     - {{ pin_subpackage('cairo') }}
 


### PR DESCRIPTION
At long last, a new minor version of Cairo was recently released.

Cairo is pretty foundational, so we don't want to just upgrade to the new release instantly, but this PR will at least let us see if it builds.