### PR TITLE
REF: Split libraries into separate outputs

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -33,6 +33,9 @@ jobs:
 
   - script: |
         export CI=azure
+        export flow_run_id=azure_$(Build.BuildNumber).$(System.JobAttempt)
+        export remote_url=$(Build.Repository.Uri)
+        export sha=$(Build.SourceVersion)
         export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
         export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
         if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -24,6 +24,7 @@ jobs:
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
         SHORT_CONFIG: linux_ppc64le_
   timeoutInMinutes: 360
+  variables: {}
 
   steps:
   # configure qemu binfmt-misc running.  This allows us to run docker containers

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,14 +12,17 @@ jobs:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_64_
       linux_aarch64_:
         CONFIG: linux_aarch64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_aarch64_
       linux_ppc64le_:
         CONFIG: linux_ppc64le_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_ppc64le_
   timeoutInMinutes: 360
 
   steps:
@@ -49,3 +52,32 @@ jobs:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
       FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
       STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
+  - script: |
+        export CI=azure
+        export CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
+        export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+        export CONDA_BLD_DIR=build_artifacts
+        export ARTIFACT_STAGING_DIR="$(Build.ArtifactStagingDirectory)"
+        # Archive everything in CONDA_BLD_DIR except environments
+        export BLD_ARTIFACT_PREFIX=conda_artifacts
+        if [[ "$AGENT_JOBSTATUS" == "Failed" ]]; then
+          # Archive the CONDA_BLD_DIR environments only when the job fails
+          export ENV_ARTIFACT_PREFIX=conda_envs
+        fi
+        ./.scripts/create_conda_build_artifacts.sh
+    displayName: Prepare conda build artifacts
+    condition: succeededOrFailed()
+
+  - task: PublishPipelineArtifact@1
+    displayName: Store conda build artifacts
+    condition: not(eq(variables.BLD_ARTIFACT_PATH, ''))
+    inputs:
+      targetPath: $(BLD_ARTIFACT_PATH)
+      artifactName: $(BLD_ARTIFACT_NAME)
+
+  - task: PublishPipelineArtifact@1
+    displayName: Store conda build environment artifacts
+    condition: not(eq(variables.ENV_ARTIFACT_PATH, ''))
+    inputs:
+      targetPath: $(ENV_ARTIFACT_PATH)
+      artifactName: $(ENV_ARTIFACT_NAME)

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -20,6 +20,9 @@ jobs:
   # TODO: Fast finish on azure pipelines?
   - script: |
       export CI=azure
+      export flow_run_id=azure_$(Build.BuildNumber).$(System.JobAttempt)
+      export remote_url=$(Build.Repository.Uri)
+      export sha=$(Build.SourceVersion)
       export OSX_FORCE_SDK_DOWNLOAD="1"
       export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
       export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -17,6 +17,7 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         SHORT_CONFIG: osx_arm64_
   timeoutInMinutes: 360
+  variables: {}
 
   steps:
   # TODO: Fast finish on azure pipelines?

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -11,9 +11,11 @@ jobs:
       osx_64_:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_64_
       osx_arm64_:
         CONFIG: osx_arm64_
         UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_arm64_
   timeoutInMinutes: 360
 
   steps:
@@ -37,3 +39,32 @@ jobs:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
       FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
       STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
+  - script: |
+      export CI=azure
+      export CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
+      export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+      export CONDA_BLD_DIR=/Users/runner/miniforge3/conda-bld
+      export ARTIFACT_STAGING_DIR="$(Build.ArtifactStagingDirectory)"
+      # Archive everything in CONDA_BLD_DIR except environments
+      export BLD_ARTIFACT_PREFIX=conda_artifacts
+      if [[ "$AGENT_JOBSTATUS" == "Failed" ]]; then
+        # Archive the CONDA_BLD_DIR environments only when the job fails
+        export ENV_ARTIFACT_PREFIX=conda_envs
+      fi
+      ./.scripts/create_conda_build_artifacts.sh
+    displayName: Prepare conda build artifacts
+    condition: succeededOrFailed()
+
+  - task: PublishPipelineArtifact@1
+    displayName: Store conda build artifacts
+    condition: not(eq(variables.BLD_ARTIFACT_PATH, ''))
+    inputs:
+      targetPath: $(BLD_ARTIFACT_PATH)
+      artifactName: $(BLD_ARTIFACT_NAME)
+
+  - task: PublishPipelineArtifact@1
+    displayName: Store conda build environment artifacts
+    condition: not(eq(variables.ENV_ARTIFACT_PATH, ''))
+    inputs:
+      targetPath: $(ENV_ARTIFACT_PATH)
+      artifactName: $(ENV_ARTIFACT_NAME)

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -42,6 +42,9 @@ jobs:
         PYTHONUNBUFFERED: 1
         CONFIG: $(CONFIG)
         CI: azure
+        flow_run_id: azure_$(Build.BuildNumber).$(System.JobAttempt)
+        remote_url: $(Build.Repository.Uri)
+        sha: $(Build.SourceVersion)
         UPLOAD_PACKAGES: $(UPLOAD_PACKAGES)
         UPLOAD_TEMP: $(UPLOAD_TEMP)
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -11,6 +11,7 @@ jobs:
       win_64_:
         CONFIG: win_64_
         UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: win_64_
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\
@@ -50,3 +51,30 @@ jobs:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)
         FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
         STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)
+    - script: |
+        set CI=azure
+        set CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
+        set FEEDSTOCK_NAME=$(build.Repository.Name)
+        set ARTIFACT_STAGING_DIR=$(Build.ArtifactStagingDirectory)
+        set CONDA_BLD_DIR=$(CONDA_BLD_PATH)
+        set BLD_ARTIFACT_PREFIX=conda_artifacts
+        if "%AGENT_JOBSTATUS%" == "Failed" (
+            set ENV_ARTIFACT_PREFIX=conda_envs
+        )
+        call ".scripts\create_conda_build_artifacts.bat"
+      displayName: Prepare conda build artifacts
+      condition: succeededOrFailed()
+
+    - task: PublishPipelineArtifact@1
+      displayName: Store conda build artifacts
+      condition: not(eq(variables.BLD_ARTIFACT_PATH, ''))
+      inputs:
+        targetPath: $(BLD_ARTIFACT_PATH)
+        artifactName: $(BLD_ARTIFACT_NAME)
+
+    - task: PublishPipelineArtifact@1
+      displayName: Store conda build environment artifacts
+      condition: not(eq(variables.ENV_ARTIFACT_PATH, ''))
+      inputs:
+        targetPath: $(ENV_ARTIFACT_PATH)
+        artifactName: $(ENV_ARTIFACT_NAME)

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+cairo:
+- '1'
 cdt_name:
 - cos6
 channel_sources:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -2,6 +2,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.12'
 cairo:
 - '1'
 cdt_name:
@@ -37,5 +41,7 @@ xz:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name
 zlib:
 - '1.2'

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -4,6 +4,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cairo:
 - '1'
 cdt_arch:
@@ -41,5 +45,7 @@ xz:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name
 zlib:
 - '1.2'

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -4,6 +4,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+cairo:
+- '1'
 cdt_arch:
 - aarch64
 cdt_name:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -2,6 +2,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
 cairo:
 - '1'
 cdt_name:
@@ -37,5 +41,7 @@ xz:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name
 zlib:
 - '1.2'

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+cairo:
+- '1'
 cdt_name:
 - cos7
 channel_sources:

--- a/.ci_support/migrations/icu73.yaml
+++ b/.ci_support/migrations/icu73.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-icu:
-- '73'
-migrator_ts: 1692912856.1389868

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -4,6 +4,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.9'
 cairo:
 - '1'
 channel_sources:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -4,6 +4,8 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+cairo:
+- '1'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -4,6 +4,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
 cairo:
 - '1'
 channel_sources:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -4,6 +4,8 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+cairo:
+- '1'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,5 +1,7 @@
 c_compiler:
 - vs2019
+c_stdlib:
+- vs
 cairo:
 - '1'
 channel_sources:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,5 +1,7 @@
 c_compiler:
 - vs2019
+cairo:
+- '1'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,24 @@
-*.pyc
+# User content belongs under recipe/.
+# Feedstock configuration goes in `conda-forge.yml`
+# Everything else is managed by the conda-smithy rerender process.
+# Please do not modify
 
-build_artifacts
+# Ignore all files and folders in root
+*
+!/conda-forge.yml
+
+# Don't ignore any files/folders if the parent folder is 'un-ignored'
+# This also avoids warnings when adding an already-checked file with an ignored parent.
+!/**/
+# Don't ignore any files/folders recursively in the following folders
+!/recipe/**
+!/.ci_support/**
+
+# Since we ignore files/folders recursively, any folders inside
+# build_artifacts gets ignored which trips some build systems.
+# To avoid that we 'un-ignore' all files/folders recursively
+# and only ignore the root build_artifacts folder.
+!/build_artifacts/**
+/build_artifacts
+
+*.pyc

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -68,7 +68,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda-build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -28,13 +28,15 @@ conda-build:
 pkgs_dirs:
   - ${FEEDSTOCK_ROOT}/build_artifacts/pkg_cache
   - /opt/conda/pkgs
+solver: libmamba
 
 CONDARC
+export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=3
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=3
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -66,9 +68,10 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
+        --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
     ( startgroup "Validating outputs" ) 2> /dev/null
 
     validate_recipe_outputs "${FEEDSTOCK_NAME}"

--- a/.scripts/create_conda_build_artifacts.bat
+++ b/.scripts/create_conda_build_artifacts.bat
@@ -1,0 +1,80 @@
+setlocal enableextensions enabledelayedexpansion
+
+rem INPUTS (environment variables that need to be set before calling this script):
+rem
+rem CI (azure/github_actions/UNSET)
+rem CI_RUN_ID (unique identifier for the CI job run)
+rem FEEDSTOCK_NAME
+rem CONFIG (build matrix configuration string)
+rem SHORT_CONFIG (uniquely-shortened configuration string)
+rem CONDA_BLD_DIR (path to the conda-bld directory)
+rem ARTIFACT_STAGING_DIR (use working directory if unset)
+rem BLD_ARTIFACT_PREFIX (prefix for the conda build artifact name, skip if unset)
+rem ENV_ARTIFACT_PREFIX (prefix for the conda build environments artifact name, skip if unset)
+
+rem OUTPUTS
+rem
+rem BLD_ARTIFACT_NAME
+rem BLD_ARTIFACT_PATH
+rem ENV_ARTIFACT_NAME
+rem ENV_ARTIFACT_PATH
+
+rem Check that the conda-build directory exists
+if not exist %CONDA_BLD_DIR% (
+    echo conda-build directory does not exist
+    exit 1
+)
+
+if not defined ARTIFACT_STAGING_DIR (
+    rem Set staging dir to the working dir
+    set ARTIFACT_STAGING_DIR=%cd%
+)
+
+rem Set a unique ID for the artifact(s), specialized for this particular job run
+set ARTIFACT_UNIQUE_ID=%CI_RUN_ID%_%CONFIG%
+if not "%ARTIFACT_UNIQUE_ID%" == "%ARTIFACT_UNIQUE_ID:~0,80%" (
+    set ARTIFACT_UNIQUE_ID=%CI_RUN_ID%_%SHORT_CONFIG%
+)
+
+rem Set a descriptive ID for the archive(s), specialized for this particular job run
+set ARCHIVE_UNIQUE_ID=%CI_RUN_ID%_%CONFIG%
+
+rem Make the build artifact zip
+if defined BLD_ARTIFACT_PREFIX (
+    set BLD_ARTIFACT_NAME=%BLD_ARTIFACT_PREFIX%_%ARTIFACT_UNIQUE_ID%
+    echo BLD_ARTIFACT_NAME: !BLD_ARTIFACT_NAME!
+
+    set "BLD_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%BLD_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.zip"
+    7z a "!BLD_ARTIFACT_PATH!" "%CONDA_BLD_DIR%" -xr^^!.git/ -xr^^!_*_env*/ -xr^^!*_cache/ -bb
+    if errorlevel 1 exit 1
+    echo BLD_ARTIFACT_PATH: !BLD_ARTIFACT_PATH!
+
+    if "%CI%" == "azure" (
+        echo ##vso[task.setVariable variable=BLD_ARTIFACT_NAME]!BLD_ARTIFACT_NAME!
+        echo ##vso[task.setVariable variable=BLD_ARTIFACT_PATH]!BLD_ARTIFACT_PATH!
+    )
+    if "%CI%" == "github_actions" (
+        echo BLD_ARTIFACT_NAME=!BLD_ARTIFACT_NAME!>> !GITHUB_OUTPUT!
+        echo BLD_ARTIFACT_PATH=!BLD_ARTIFACT_PATH!>> !GITHUB_OUTPUT!
+    )
+)
+
+rem Make the environments artifact zip
+if defined ENV_ARTIFACT_PREFIX (
+    set ENV_ARTIFACT_NAME=!ENV_ARTIFACT_PREFIX!_%ARTIFACT_UNIQUE_ID%
+    echo ENV_ARTIFACT_NAME: !ENV_ARTIFACT_NAME!
+
+    set "ENV_ARTIFACT_PATH=%ARTIFACT_STAGING_DIR%\%FEEDSTOCK_NAME%_%ENV_ARTIFACT_PREFIX%_%ARCHIVE_UNIQUE_ID%.zip"
+    7z a "!ENV_ARTIFACT_PATH!" -r "%CONDA_BLD_DIR%"/_*_env*/ -bb
+    if errorlevel 1 exit 1
+    echo ENV_ARTIFACT_PATH: !ENV_ARTIFACT_PATH!
+
+    if "%CI%" == "azure" (
+        echo ##vso[task.setVariable variable=ENV_ARTIFACT_NAME]!ENV_ARTIFACT_NAME!
+        echo ##vso[task.setVariable variable=ENV_ARTIFACT_PATH]!ENV_ARTIFACT_PATH!
+    )
+    if "%CI%" == "github_actions" (
+        echo ENV_ARTIFACT_NAME=!ENV_ARTIFACT_NAME!>> !GITHUB_OUTPUT!
+        echo ENV_ARTIFACT_PATH=!ENV_ARTIFACT_PATH!>> !GITHUB_OUTPUT!
+    )
+)

--- a/.scripts/create_conda_build_artifacts.sh
+++ b/.scripts/create_conda_build_artifacts.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+# INPUTS (environment variables that need to be set before calling this script):
+#
+# CI (azure/github_actions/UNSET)
+# CI_RUN_ID (unique identifier for the CI job run)
+# FEEDSTOCK_NAME
+# CONFIG (build matrix configuration string)
+# SHORT_CONFIG (uniquely-shortened configuration string)
+# CONDA_BLD_DIR (path to the conda-bld directory)
+# ARTIFACT_STAGING_DIR (use working directory if unset)
+# BLD_ARTIFACT_PREFIX (prefix for the conda build artifact name, skip if unset)
+# ENV_ARTIFACT_PREFIX (prefix for the conda build environments artifact name, skip if unset)
+
+# OUTPUTS
+#
+# BLD_ARTIFACT_NAME
+# BLD_ARTIFACT_PATH
+# ENV_ARTIFACT_NAME
+# ENV_ARTIFACT_PATH
+
+source .scripts/logging_utils.sh
+
+# DON'T do set -x, because it results in double echo-ing pipeline commands
+# and that might end up inserting extraneous quotation marks in output variables
+set -e
+
+# Check that the conda-build directory exists
+if [ ! -d "$CONDA_BLD_DIR" ]; then
+    echo "conda-build directory does not exist"
+    exit 1
+fi
+
+# Set staging dir to the working dir, in Windows style if applicable
+if [[ -z "${ARTIFACT_STAGING_DIR}" ]]; then
+    if pwd -W; then
+        ARTIFACT_STAGING_DIR=$(pwd -W)
+    else
+        ARTIFACT_STAGING_DIR=$PWD
+    fi
+fi
+echo "ARTIFACT_STAGING_DIR: $ARTIFACT_STAGING_DIR"
+
+FEEDSTOCK_ROOT=$(cd "$(dirname "$0")/.."; pwd;)
+if [ -z ${FEEDSTOCK_NAME} ]; then
+    export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
+fi
+
+# Set a unique ID for the artifact(s), specialized for this particular job run
+ARTIFACT_UNIQUE_ID="${CI_RUN_ID}_${CONFIG}"
+if [[ ${#ARTIFACT_UNIQUE_ID} -gt 80 ]]; then
+    ARTIFACT_UNIQUE_ID="${CI_RUN_ID}_${SHORT_CONFIG}"
+fi
+echo "ARTIFACT_UNIQUE_ID: $ARTIFACT_UNIQUE_ID"
+
+# Set a descriptive ID for the archive(s), specialized for this particular job run
+ARCHIVE_UNIQUE_ID="${CI_RUN_ID}_${CONFIG}"
+
+# Make the build artifact zip
+if [[ ! -z "$BLD_ARTIFACT_PREFIX" ]]; then
+    export BLD_ARTIFACT_NAME="${BLD_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
+    export BLD_ARTIFACT_PATH="${ARTIFACT_STAGING_DIR}/${FEEDSTOCK_NAME}_${BLD_ARTIFACT_PREFIX}_${ARCHIVE_UNIQUE_ID}.zip"
+
+    ( startgroup "Archive conda build directory" ) 2> /dev/null
+
+    # Try 7z and fall back to zip if it fails (for cross-platform use)
+    if ! 7z a "$BLD_ARTIFACT_PATH" "$CONDA_BLD_DIR" '-xr!.git/' '-xr!_*_env*/' '-xr!*_cache/' -bb; then
+        pushd "$CONDA_BLD_DIR"
+        zip -r -y -T "$BLD_ARTIFACT_PATH" . -x '*.git/*' '*_*_env*/*' '*_cache/*'
+        popd
+    fi
+
+    ( endgroup "Archive conda build directory" ) 2> /dev/null
+
+    echo "BLD_ARTIFACT_NAME: $BLD_ARTIFACT_NAME"
+    echo "BLD_ARTIFACT_PATH: $BLD_ARTIFACT_PATH"
+
+    if [[ "$CI" == "azure" ]]; then
+        echo "##vso[task.setVariable variable=BLD_ARTIFACT_NAME]$BLD_ARTIFACT_NAME"
+        echo "##vso[task.setVariable variable=BLD_ARTIFACT_PATH]$BLD_ARTIFACT_PATH"
+    elif [[ "$CI" == "github_actions" ]]; then
+        echo "BLD_ARTIFACT_NAME=$BLD_ARTIFACT_NAME" >> $GITHUB_OUTPUT
+        echo "BLD_ARTIFACT_PATH=$BLD_ARTIFACT_PATH" >> $GITHUB_OUTPUT
+    fi
+fi
+
+# Make the environments artifact zip
+if [[ ! -z "$ENV_ARTIFACT_PREFIX" ]]; then
+    export ENV_ARTIFACT_NAME="${ENV_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
+    export ENV_ARTIFACT_PATH="${ARTIFACT_STAGING_DIR}/${FEEDSTOCK_NAME}_${ENV_ARTIFACT_PREFIX}_${ARCHIVE_UNIQUE_ID}.zip"
+
+    ( startgroup "Archive conda build environments" ) 2> /dev/null
+
+    # Try 7z and fall back to zip if it fails (for cross-platform use)
+    if ! 7z a "$ENV_ARTIFACT_PATH" -r "$CONDA_BLD_DIR"/'_*_env*/' -bb; then
+        pushd "$CONDA_BLD_DIR"
+        zip -r -y -T "$ENV_ARTIFACT_PATH" . -i '*_*_env*/*'
+        popd
+    fi
+
+    ( endgroup "Archive conda build environments" ) 2> /dev/null
+
+    echo "ENV_ARTIFACT_NAME: $ENV_ARTIFACT_NAME"
+    echo "ENV_ARTIFACT_PATH: $ENV_ARTIFACT_PATH"
+
+    if [[ "$CI" == "azure" ]]; then
+        echo "##vso[task.setVariable variable=ENV_ARTIFACT_NAME]$ENV_ARTIFACT_NAME"
+        echo "##vso[task.setVariable variable=ENV_ARTIFACT_PATH]$ENV_ARTIFACT_PATH"
+    elif [[ "$CI" == "github_actions" ]]; then
+        echo "ENV_ARTIFACT_NAME=$ENV_ARTIFACT_NAME" >> $GITHUB_OUTPUT
+        echo "ENV_ARTIFACT_PATH=$ENV_ARTIFACT_PATH" >> $GITHUB_OUTPUT
+    fi
+fi

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -21,6 +21,12 @@ if [ -z ${FEEDSTOCK_NAME} ]; then
     export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
 fi
 
+if [[ "${sha:-}" == "" ]]; then
+  pushd "${FEEDSTOCK_ROOT}"
+  sha=$(git rev-parse HEAD)
+  popd
+fi
+
 docker info
 
 # In order for the conda-build process in the container to write to the mounted
@@ -91,6 +97,9 @@ docker run ${DOCKER_RUN_ARGS} \
            -e CPU_COUNT \
            -e BUILD_WITH_CONDA_DEBUG \
            -e BUILD_OUTPUT_ID \
+           -e flow_run_id \
+           -e remote_url \
+           -e sha \
            -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -81,7 +81,7 @@ else
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
     fi
 
-    conda build ./recipe -m ./.ci_support/${CONFIG}.yaml \
+    conda-build ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
         --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -22,11 +22,13 @@ bash $MINIFORGE_FILE -b -p ${MINIFORGE_HOME}
 
 source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
+export CONDA_SOLVER="libmamba"
+export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --quiet --yes --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=3
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=3
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 
 
 
@@ -43,6 +45,10 @@ if [[ "${CI:-}" != "" ]]; then
   /usr/bin/sudo -k
 else
   echo -e "\n\nNot mangling homebrew as we are not running in CI"
+fi
+
+if [[ "${sha:-}" == "" ]]; then
+  sha=$(git rev-parse HEAD)
 fi
 
 echo -e "\n\nRunning the build setup script."
@@ -75,9 +81,10 @@ else
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
     fi
 
-    conda mambabuild ./recipe -m ./.ci_support/${CONFIG}.yaml \
+    conda build ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+        --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
+        --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"
     ( startgroup "Validating outputs" ) 2> /dev/null
 
     validate_recipe_outputs "${FEEDSTOCK_NAME}"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -55,7 +55,7 @@ call :end_group
 
 :: Build the recipe
 echo Building recipe
-conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
+conda-build.exe "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 :: Prepare some environment variables for the upload step

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -17,10 +17,14 @@ call :start_group "Configuring conda"
 
 :: Activate the base conda environment
 call activate base
+:: Configure the solver
+set "CONDA_SOLVER=libmamba"
+if !errorlevel! neq 0 exit /b !errorlevel!
+set "CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1"
 
 :: Provision the necessary dependencies to build the recipe later
 echo Installing dependencies
-mamba.exe install "python=3.10" pip mamba conda-build boa conda-forge-ci-setup=3 -c conda-forge --strict-channel-priority --yes
+mamba.exe install "python=3.10" pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1" -c conda-forge --strict-channel-priority --yes
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 :: Set basic configuration
@@ -38,14 +42,20 @@ if EXIST LICENSE.txt (
     copy LICENSE.txt "recipe\\recipe-scripts-license.txt"
 )
 if NOT [%HOST_PLATFORM%] == [%BUILD_PLATFORM%] (
-    set "EXTRA_CB_OPTIONS=%EXTRA_CB_OPTIONS% --no-test"
+    if [%CROSSCOMPILING_EMULATOR%] == [] (
+        set "EXTRA_CB_OPTIONS=%EXTRA_CB_OPTIONS% --no-test"
+    )
+)
+
+if NOT [%flow_run_id%] == [] (
+    set "EXTRA_CB_OPTIONS=%EXTRA_CB_OPTIONS% --extra-meta flow_run_id=%flow_run_id% remote_url=%remote_url% sha=%sha%"
 )
 
 call :end_group
 
 :: Build the recipe
 echo Building recipe
-conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
+conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 :: Prepare some environment variables for the upload step

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-About cairo-split-feedstock
-===========================
+About ['cairo']-feedstock
+=================
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/cairo-feedstock/blob/main/LICENSE.txt)
 
 
-About cairo-split
------------------
+About ['cairo']
+-------
 
 Home: http://cairographics.org/
 
@@ -104,10 +104,10 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-libcairo--static-green.svg)](https://anaconda.org/conda-forge/libcairo-static) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libcairo-static.svg)](https://anaconda.org/conda-forge/libcairo-static) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libcairo-static.svg)](https://anaconda.org/conda-forge/libcairo-static) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libcairo-static.svg)](https://anaconda.org/conda-forge/libcairo-static) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-libcairo2-green.svg)](https://anaconda.org/conda-forge/libcairo2) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libcairo2.svg)](https://anaconda.org/conda-forge/libcairo2) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libcairo2.svg)](https://anaconda.org/conda-forge/libcairo2) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libcairo2.svg)](https://anaconda.org/conda-forge/libcairo2) |
 
-Installing cairo-split
-======================
+Installing ['cairo']
+============
 
-Installing `cairo-split` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `['cairo']` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
@@ -193,17 +193,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating cairo-split-feedstock
-==============================
+Updating ['cairo']-feedstock
+====================
 
-If you would like to improve the cairo-split recipe or build a new
+If you would like to improve the ['cairo'] recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/cairo-split-feedstock are
+Note that all branches in the conda-forge/['cairo']-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-About cairo-feedstock
-=====================
+About cairo-split-feedstock
+===========================
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/cairo-feedstock/blob/main/LICENSE.txt)
+
+
+About cairo-split
+-----------------
 
 Home: http://cairographics.org/
 
@@ -12,6 +16,16 @@ Summary: Cairo is a 2D graphics library with support for multiple output devices
 Development: https://gitlab.freedesktop.org/cairo/cairo
 
 Documentation: https://www.cairographics.org/documentation/
+
+About _libcairo_api
+-------------------
+
+
+
+Package license: 
+
+Summary: An empty package that prevents multiple ABIs of this package from being installed simultaneously on Windows.
+
 
 Current build status
 ====================
@@ -85,53 +99,56 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-_libcairo_api-green.svg)](https://anaconda.org/conda-forge/_libcairo_api) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/_libcairo_api.svg)](https://anaconda.org/conda-forge/_libcairo_api) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/_libcairo_api.svg)](https://anaconda.org/conda-forge/_libcairo_api) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/_libcairo_api.svg)](https://anaconda.org/conda-forge/_libcairo_api) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-cairo-green.svg)](https://anaconda.org/conda-forge/cairo) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/cairo.svg)](https://anaconda.org/conda-forge/cairo) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/cairo.svg)](https://anaconda.org/conda-forge/cairo) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/cairo.svg)](https://anaconda.org/conda-forge/cairo) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-libcairo--static-green.svg)](https://anaconda.org/conda-forge/libcairo-static) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libcairo-static.svg)](https://anaconda.org/conda-forge/libcairo-static) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libcairo-static.svg)](https://anaconda.org/conda-forge/libcairo-static) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libcairo-static.svg)](https://anaconda.org/conda-forge/libcairo-static) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-libcairo2-green.svg)](https://anaconda.org/conda-forge/libcairo2) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libcairo2.svg)](https://anaconda.org/conda-forge/libcairo2) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libcairo2.svg)](https://anaconda.org/conda-forge/libcairo2) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libcairo2.svg)](https://anaconda.org/conda-forge/libcairo2) |
 
-Installing cairo
-================
+Installing cairo-split
+======================
 
-Installing `cairo` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `cairo-split` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `cairo` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `_libcairo_api, cairo, libcairo-static, libcairo2` can be installed with `conda`:
 
 ```
-conda install cairo
-```
-
-or with `mamba`:
-
-```
-mamba install cairo
-```
-
-It is possible to list all of the versions of `cairo` available on your platform with `conda`:
-
-```
-conda search cairo --channel conda-forge
+conda install _libcairo_api cairo libcairo-static libcairo2
 ```
 
 or with `mamba`:
 
 ```
-mamba search cairo --channel conda-forge
+mamba install _libcairo_api cairo libcairo-static libcairo2
+```
+
+It is possible to list all of the versions of `_libcairo_api` available on your platform with `conda`:
+
+```
+conda search _libcairo_api --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search _libcairo_api --channel conda-forge
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search cairo --channel conda-forge
+mamba repoquery search _libcairo_api --channel conda-forge
 
-# List packages depending on `cairo`:
-mamba repoquery whoneeds cairo --channel conda-forge
+# List packages depending on `_libcairo_api`:
+mamba repoquery whoneeds _libcairo_api --channel conda-forge
 
-# List dependencies of `cairo`:
-mamba repoquery depends cairo --channel conda-forge
+# List dependencies of `_libcairo_api`:
+mamba repoquery depends _libcairo_api --channel conda-forge
 ```
 
 
@@ -153,7 +170,7 @@ available continuous integration services. Thanks to the awesome service provide
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/),
 [Drone](https://cloud.drone.io/welcome), and [TravisCI](https://travis-ci.com/)
 it is possible to build and upload installable packages to the
-[conda-forge](https://anaconda.org/conda-forge) [Anaconda-Cloud](https://anaconda.org/)
+[conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance
@@ -176,17 +193,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating cairo-feedstock
-========================
+Updating cairo-split-feedstock
+==============================
 
-If you would like to improve the cairo recipe or build a new
+If you would like to improve the cairo-split recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/cairo-feedstock are
+Note that all branches in the conda-forge/cairo-split-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,5 +4,5 @@
 
 jobs:
   - template: ./.azure-pipelines/azure-pipelines-linux.yml
-  - template: ./.azure-pipelines/azure-pipelines-win.yml
   - template: ./.azure-pipelines/azure-pipelines-osx.yml
+  - template: ./.azure-pipelines/azure-pipelines-win.yml

--- a/build-locally.py
+++ b/build-locally.py
@@ -64,8 +64,9 @@ def verify_config(ns):
     elif ns.config.startswith("osx"):
         if "OSX_SDK_DIR" not in os.environ:
             raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=SDKs' "
-                "to download the SDK automatically to 'SDKs/MacOSX<ver>.sdk'. "
+                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+                "Note: OSX_SDK_DIR must be set to an absolute path. "
                 "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
             )
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -13,3 +13,5 @@ provider:
   linux_ppc64le: default
   win: azure
 test_on_native_only: true
+azure:
+  store_build_artifacts: True

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,7 +5,7 @@ mkdir "%SRC_DIR%\stage"
 set "PKG_CONFIG_PATH=%LIBRARY_LIB%\pkgconfig;%LIBRARY_PREFIX%\share\pkgconfig;%BUILD_PREFIX%\Library\lib\pkgconfig"
 
 :: get the prefix in "mixed" form
-set "LIBRARY_PREFIX_M=%SRC_DIR\stage:\=/%"
+set "LIBRARY_PREFIX_M=%SRC_DIR%\stage"
 
 %BUILD_PREFIX%\Scripts\meson setup builddir ^
   --buildtype=release ^

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -30,5 +30,3 @@ for %%f in ( "%SRC_DIR%\stage\lib\pkgconfig\*.pc" ) do (
     del %%f.bak
 )
 endlocal
-sed -i.bak "s,prefix=.*,prefix=/opt/anaconda1anaconda2anaconda3/Library,g" %SRC_DIR%\stage\bin\cairo-trace
-del %SRC_DIR%\stage\bin\cairo-trace.bak

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,9 +1,11 @@
 @ECHO ON
 
+mkdir "%SRC_DIR%\stage"
+
 set "PKG_CONFIG_PATH=%LIBRARY_LIB%\pkgconfig;%LIBRARY_PREFIX%\share\pkgconfig;%BUILD_PREFIX%\Library\lib\pkgconfig"
 
 :: get the prefix in "mixed" form
-set "LIBRARY_PREFIX_M=%LIBRARY_PREFIX:\=/%"
+set "LIBRARY_PREFIX_M=%SRC_DIR\stage:\=/%"
 
 %BUILD_PREFIX%\Scripts\meson setup builddir ^
   --buildtype=release ^
@@ -22,3 +24,11 @@ if errorlevel 1 exit 1
 ninja -C builddir install -j %CPU_COUNT%
 if errorlevel 1 exit 1
 
+setlocal EnableExtensions EnableDelayedExpansion
+for %%f in ( "%SRC_DIR%\stage\lib\pkgconfig\*.pc" ) do (
+    sed -i.bak "s,prefix=.*,prefix=/opt/anaconda1anaconda2anaconda3/Library,g" %%f
+    del %%f.bak
+)
+endlocal
+sed -i.bak "s,prefix=.*,prefix=/opt/anaconda1anaconda2anaconda3/Library,g" %SRC_DIR%\stage\bin\cairo-trace
+del %SRC_DIR%\stage\bin\cairo-trace.bak

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+mkdir "$SRC_DIR/stage"
+
 export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$BUILD_PREFIX/lib/pkgconfig
 export PKG_CONFIG=$BUILD_PREFIX/bin/pkg-config
 
@@ -35,8 +37,14 @@ meson setup builddir \
     "${meson_config_args[@]}" \
     --buildtype=release \
     --default-library=both \
-    --prefix=$PREFIX \
+    --prefix=$SRC_DIR/stage \
     -Dlibdir=lib \
     --wrap-mode=nofallback
 ninja -v -C builddir -j ${CPU_COUNT}
 ninja -C builddir install -j ${CPU_COUNT}
+
+sed -i.bak "s,$SRC_DIR/stage,/opt/anaconda1anaconda2anaconda3,g" $SRC_DIR/stage/lib/pkgconfig/*.pc
+rm $SRC_DIR/stage/lib/pkgconfig/*.bak
+
+sed -i.bak "s,$SRC_DIR/stage,/opt/anaconda1anaconda2anaconda3,g" $SRC_DIR/stage/bin/cairo-trace
+rm $SRC_DIR/stage/bin/cairo-trace.bak

--- a/recipe/install.py
+++ b/recipe/install.py
@@ -1,0 +1,167 @@
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# For more information, please refer to <https://unlicense.org>
+
+"""A python install script for conda-build recipes with multiple outputs
+
+Used in outputs/script to split the files of a top-level package into multiple
+outputs instead of using the outputs/files dictionary of globs. The advantage
+of this approach is that you don't need to choose glob expressions that include
+files installed by this package while excluding files installed by the host
+dependencies. For example, this script just globs "include", whereas using
+outputs/files, you would need to glob "include/foo.h", "include/foo" and
+possibly others in order to exclude the headers from dependencies.
+
+To use this script, set your install prefix in your build script to a new
+directory named `$SRC_DIR / stage`. Change `basename` to the basename of the
+package. Replace the stage directory with the conda prefix placeholder in any
+pkg-config files using sed. i.e.
+
+on unix
+sed -i.bak "s,$SRC_DIR/stage,/opt/anaconda1anaconda2anaconda3,g" $SRC_DIR/stage/lib/pkgconfig/*.pc
+rm $SRC_DIR/stage/lib/pkgconfig/*.bak
+
+on windows with m2-sed installed
+setlocal EnableExtensions ENABLEDELAYEDEXPANSION
+for %%f in ( "%SRC_DIR%\stage\lib\pkgconfig\*.pc" ) do (
+    sed -i.bak "s,prefix=.*,prefix=/opt/anaconda1anaconda2anaconda3/Library,g" %%f
+    del %%f.bak
+)
+endlocal
+
+https://gist.github.com/carterbox/188ac74647e703cfa6700b58b076d712
+"""
+
+import os
+import pathlib
+import re
+import shutil
+import typing
+import itertools
+
+target_platform = os.environ["target_platform"]
+STAGE = pathlib.Path(os.environ["SRC_DIR"]) / "stage"
+PREFIX = pathlib.Path(os.environ["PREFIX"])
+if target_platform[:3] == "win":
+    PREFIX = PREFIX / "Library"
+
+
+def glob_install(
+    include: typing.List[str],
+    exclude: typing.List[str] = [],
+):
+    """Install files and symlinks (broken or not) from the glob expressions."""
+    included = set(itertools.chain(*(STAGE.glob(item) for item in include)))
+    excluded = set(itertools.chain(*(STAGE.glob(item) for item in exclude)))
+    for match in sorted(included - excluded):
+        match = pathlib.Path(match)
+        if match.is_file() or match.is_symlink():
+            relative = match.relative_to(STAGE)
+            print(relative)
+            os.makedirs((PREFIX / relative).parent, exist_ok=True)
+            shutil.copy(
+                match,
+                PREFIX / relative,
+                # copy the link itself; not the linked-file
+                follow_symlinks=False,
+            )
+
+
+def sort_artifacts_based_on_name(basename):
+    PKG_NAME = os.environ["PKG_NAME"]
+
+    print(f"Installing {PKG_NAME} to {PREFIX} for {target_platform}")
+    print("Based on the package name, ", end="")
+
+    if PKG_NAME.endswith("-split"):
+        raise ValueError("The top level package should not run this script.")
+
+    # libfoo OR foo-dev OR libfoo-dev
+    # dav1d-dev, v8-dev, m-dev, secp256k1-dev
+    # libdav1d, libv8, libm, libsecp256k1
+    # libdav1d-dev, libv8-dev, libm-dev, libsecp256k1-dev
+    if (
+        PKG_NAME == basename
+    ):
+        print("this package is needed for compiling/linking.")
+        glob_install(
+            include=[
+                "bin/**/*",
+                "doc/**/*",
+                "share/**/*",
+                "include/**/*",
+                "lib/**/*",
+            ],
+            exclude=[
+                # versioned libs
+                "lib/**/lib*.*.dylib",
+                "lib/**/lib*.so.*",
+                # static libs
+                "lib/**/*.a",
+                "lib/**/lib*.lib",
+                "lib/**/*.a.lib",
+                "lib/**/*_a.lib",
+                "lib/**/*static.lib",
+                "lib/**/*static*",
+                "bin/**/*.dll",
+            ],
+        )
+        return
+
+    # libfoo1
+    # libdav1d1, libv8-1, libm1, libsecp256k1-1
+    if re.match(f"^lib{ basename }-?[0-9]+$", PKG_NAME):
+        print("this package is versioned so/dylib, dlls.")
+        glob_install(
+            include=[
+                "bin/**/*.dll",
+                "lib/**/lib*.*.dylib",
+                "lib/**/lib*.so.*",
+            ]
+        )
+        return
+
+    # libfoo-static
+    # libdav1d-static, libv8-static, libm-static, libsecp256k1-static
+    if PKG_NAME == f"lib{ basename }-static":
+        print("this package is anything needed for static linking.")
+        glob_install(
+            include=[
+                "lib/**/lib*.a",
+                "lib/**/lib*.lib",
+                "lib/**/*.a.lib",
+                "lib/**/*_a.lib",
+                "lib/**/*static.lib",
+                "lib/**/*static*",
+            ]
+        )
+        # FIXME: Add static library files here; exclude above
+        return
+
+    print("this package has unknown purpose!")
+    raise ValueError("None of the packages names matched!")
+
+
+if __name__ == "__main__":
+    sort_artifacts_based_on_name(basename="cairo")

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -200,8 +200,7 @@ about:
   summary: 'Cairo is a 2D graphics library with support for multiple output devices.'
 
 extra:
-  feedstock-name:
-    - cairo
+  feedstock-name: cairo
   recipe-maintainers:
     - ccordoba12
     - jakirkham

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,9 +60,9 @@ outputs:
         - pthread-stubs         # [linux]
       host:
         - zlib
-        - {{ pin_subpackage('libcairo' ~ so_name_major, exact=True) }}        # [unix]
+        - {{ pin_subpackage('libcairo' ~ so_name_major, exact=True) }}
       run:
-        - {{ pin_subpackage('libcairo' ~ so_name_major, exact=True) }}        # [unix]
+        - {{ pin_subpackage('libcairo' ~ so_name_major, exact=True) }}
         # hmaarrfk: 2022/08
         # While the dependencies below should be captured
         # by run_exports, run_exports doesn't necessary
@@ -89,7 +89,6 @@ outputs:
         - test ! -f $PREFIX/lib/lib{{ each_cairo_lib }}.a                   # [not win]
         - test   -f $PREFIX/lib/lib{{ each_cairo_lib }}.dylib               # [osx]
         - test   -f $PREFIX/lib/lib{{ each_cairo_lib }}.so                  # [linux]
-        - if     exist %LIBRARY_BIN%\{{ each_cairo_lib }}.dll exit /b 1   # [win]
         - if not exist %LIBRARY_LIB%\{{ each_cairo_lib }}.lib exit /b 1   # [win]
         - if     exist %LIBRARY_LIB%\lib{{ each_cairo_lib }}.a exit /b 1  # [win]
         {% endfor %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -201,7 +201,7 @@ about:
   summary: 'Cairo is a 2D graphics library with support for multiple output devices.'
 
 extra:
-  feestock-name:
+  feedstock-name:
     - cairo
   recipe-maintainers:
     - ccordoba12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,9 @@
 {% set version = "1.18.0" %}
+{% set so_name = "2.11800.0" %}
+{% set so_name_major = so_name.split('.')[0] %}
 
 package:
-  name: cairo
+  name: cairo-split
   version: {{ version }}
 
 source:
@@ -12,13 +14,12 @@ source:
     - windows-soversion-continuity.patch  # [win]
 
 build:
-  number: 0
-  run_exports:
-    - {{ pin_subpackage('cairo') }}
+  number: 1
 
 requirements:
   build:
     - m2w64-xz              # [win]
+    - m2-sed                # [win]
     - xz                    # [not win]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
@@ -43,61 +44,150 @@ requirements:
     - xorg-libxext  # [linux]
     - xorg-libxrender  # [linux]
     - zlib
-  run:
-    - xorg-libice  # [linux]
-    - xorg-libsm  # [linux]
-    - xorg-libx11  # [linux]
-    - xorg-libxext  # [linux]
-    - xorg-libxrender  # [linux]
-    # hmaarrfk: 2022/08
-    # While the dependencies below should be captured
-    # by run_exports, run_exports doesn't necessary
-    # bring in compile time depenencies
-    - zlib
 
-test:
-  requires:
-    - glib  # needed for the pkg-config invocations below
-    - pkg-config
+outputs:
 
-  commands:
-    # Check commands.
-    - cairo-trace --help  # [not win]
+  # Everything needed to build against libcairo
+  - name: cairo
+    script: install.py
+    build:
+      run_exports:
+        - {{ pin_subpackage('libcairo' ~ so_name_major) }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - pthread-stubs         # [linux]
+      host:
+        - zlib
+        - {{ pin_subpackage('libcairo' ~ so_name_major, exact=True) }}        # [unix]
+      run:
+        - {{ pin_subpackage('libcairo' ~ so_name_major, exact=True) }}        # [unix]
+        # hmaarrfk: 2022/08
+        # While the dependencies below should be captured
+        # by run_exports, run_exports doesn't necessary
+        # bring in compile time depenencies
+        - zlib
+    test:
+      requires:
+        - glib  # needed for the pkg-config invocations below
+        - pkg-config
 
-    # Verify libraries. Note that on Windows, we patch Cairo's build system to
-    # produce DLL names like `cairo.dll` rather than `cairo-2.dll` to maintain
-    # continuity with binaries shipped before the switch to Meson.
-    {% set cairo_libs = [
-            "cairo",
-            "cairo-gobject",
-            "cairo-script-interpreter",
-    ] %}
-    {% for each_cairo_lib in cairo_libs %}
-    - test -f $PREFIX/lib/lib{{ each_cairo_lib }}.a                   # [not win]
-    - test -f $PREFIX/lib/lib{{ each_cairo_lib }}.dylib               # [osx]
-    - test -f $PREFIX/lib/lib{{ each_cairo_lib }}.so                  # [linux]
-    - if not exist %LIBRARY_BIN%\{{ each_cairo_lib }}.dll exit /b 1   # [win]
-    - if not exist %LIBRARY_LIB%\{{ each_cairo_lib }}.lib exit /b 1   # [win]
-    - if not exist %LIBRARY_LIB%\lib{{ each_cairo_lib }}.a exit /b 1  # [win]
-    {% endfor %}
+      commands:
+        # Check commands.
+        - cairo-trace --help  # [not win]
 
-    # Check pkg-config files.
-    - test -f $PREFIX/lib/pkgconfig/cairo-quartz.pc                  # [osx]
-    - test -f $PREFIX/lib/pkgconfig/cairo-xlib.pc                    # [linux]
-    - if not exist %LIBRARY_LIB%\pkgconfig\cairo-win32.pc exit /b 1  # [win]
+        # Verify libraries. Note that on Windows, we patch Cairo's build system to
+        # produce DLL names like `cairo.dll` rather than `cairo-2.dll` to maintain
+        # continuity with binaries shipped before the switch to Meson.
+        {% set cairo_libs = [
+                "cairo",
+                "cairo-gobject",
+                "cairo-script-interpreter",
+        ] %}
+        {% for each_cairo_lib in cairo_libs %}
+        - test ! -f $PREFIX/lib/lib{{ each_cairo_lib }}.a                   # [not win]
+        - test   -f $PREFIX/lib/lib{{ each_cairo_lib }}.dylib               # [osx]
+        - test   -f $PREFIX/lib/lib{{ each_cairo_lib }}.so                  # [linux]
+        - if     exist %LIBRARY_BIN%\{{ each_cairo_lib }}.dll exit /b 1   # [win]
+        - if not exist %LIBRARY_LIB%\{{ each_cairo_lib }}.lib exit /b 1   # [win]
+        - if     exist %LIBRARY_LIB%\lib{{ each_cairo_lib }}.a exit /b 1  # [win]
+        {% endfor %}
 
-    # check include files
-    - test -f $PREFIX/include/cairo/cairo.h               # [unix]
-    - if not exist %LIBRARY_INC%\cairo\cairo.h exit /b 1  # [win]
+        # Check pkg-config files.
+        - test -f $PREFIX/lib/pkgconfig/cairo-quartz.pc                  # [osx]
+        - test -f $PREFIX/lib/pkgconfig/cairo-xlib.pc                    # [linux]
+        - if not exist %LIBRARY_LIB%\pkgconfig\cairo-win32.pc exit /b 1  # [win]
 
-    # check that cairo was built with fontconfig support
-    - grep -q "CAIRO_HAS_FC_FONT 1" $PREFIX/include/cairo/cairo-features.h  # [unix]
+        # check include files
+        - test -f $PREFIX/include/cairo/cairo.h               # [unix]
+        - if not exist %LIBRARY_INC%\cairo\cairo.h exit /b 1  # [win]
 
-    - export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig   # [not win]
-    - set "PKG_CONFIG_PATH=%LIBRARY_LIB%\pkgconfig"  # [win]
-    - pkg-config --cflags cairo
-    - pkg-config --cflags cairo-fc
-    - pkg-config --cflags cairo-gobject
+        # check that cairo was built with fontconfig support
+        - grep -q "CAIRO_HAS_FC_FONT 1" $PREFIX/include/cairo/cairo-features.h  # [unix]
+
+        - export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig   # [not win]
+        - set "PKG_CONFIG_PATH=%LIBRARY_LIB%\pkgconfig"  # [win]
+        - pkg-config --cflags cairo
+        - pkg-config --cflags cairo-fc
+        - pkg-config --cflags cairo-gobject
+
+  # Only what's needed for run_exports downstream
+  - name: libcairo{{ so_name_major }}
+    script: install.py
+    build:
+      run_exports:
+        - {{ pin_subpackage('libcairo' ~ so_name_major) }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - pthread-stubs         # [linux]
+        - xcb-proto             # [linux]
+        - xorg-renderproto      # [linux]
+        - xorg-xproto           # [linux]
+      host:
+        - freetype
+        - fontconfig
+        - glib
+        - icu
+        - libpng
+        - libxcb                # [linux]
+        - pixman
+        - xorg-libice  # [linux]
+        - xorg-libsm  # [linux]
+        - xorg-libx11  # [linux]
+        - xorg-libxext  # [linux]
+        - xorg-libxrender  # [linux]
+        - zlib
+      run:
+        - xorg-libice  # [linux]
+        - xorg-libsm  # [linux]
+        - xorg-libx11  # [linux]
+        - xorg-libxext  # [linux]
+        - xorg-libxrender  # [linux]
+        - {{ pin_subpackage('_libcairo_api', max_pin='x.x.x') }}              # [win]
+    test:
+      commands:
+        {% set cairo_libs = [
+                "cairo",
+                "cairo-gobject",
+                "cairo-script-interpreter",
+        ] %}
+        {% for each_cairo_lib in cairo_libs %}
+        - test -f ${PREFIX}/lib/lib{{ each_cairo_lib }}.{{ so_name_major }}{{ SHLIB_EXT }}   # [osx]
+        - test -f ${PREFIX}/lib/lib{{ each_cairo_lib }}{{ SHLIB_EXT }}.{{ so_name_major }}   # [linux]
+        - test -f ${PREFIX}/lib/lib{{ each_cairo_lib }}{{ SHLIB_EXT }}.{{ so_name }}         # [linux]
+        - if not exist %PREFIX%\\Library\\bin\\{{ each_cairo_lib }}.dll exit 1               # [win]
+        {% endfor %}
+
+  - name: libcairo-static
+    script: install.py
+    requirements:
+      run:
+        - {{ pin_subpackage('cairo', exact=True) }}
+        - {{ pin_subpackage('_libcairo_api', max_pin='x.x.x') }}              # [win]
+    test:
+      commands:
+        {% set cairo_libs = [
+                "cairo",
+                "cairo-gobject",
+                "cairo-script-interpreter",
+        ] %}
+        {% for each_cairo_lib in cairo_libs %}
+        - test -f $PREFIX/lib/lib{{ each_cairo_lib }}.a                   # [not win]
+        - if not exist %LIBRARY_LIB%\lib{{ each_cairo_lib }}.a exit /b 1  # [win]
+        {% endfor %}
+
+  # Clobber preventer for Windows; prevents multiple cairo.dll files from being
+  # installed simultaneously. This lets us avoid exporting a strict pin on the
+  # libcairo API which is not strictly correlated with the ABI.
+  - name: _libcairo_api
+    build:
+      skip: true  # [not win]
+    about:
+      summary: >
+        An empty package that prevents multiple ABIs of this package from
+        being installed simultaneously on Windows.
 
 about:
   home: http://cairographics.org/
@@ -111,6 +201,8 @@ about:
   summary: 'Cairo is a 2D graphics library with support for multiple output devices.'
 
 extra:
+  feestock-name:
+    - cairo
   recipe-maintainers:
     - ccordoba12
     - jakirkham


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Hi maintainers!

It looks like this feedstock is still shipping static libraries. It has been our channel's policy since 2020 that static libraries are not shipped or are separated into their own output. For more information about our static library policy, [please read CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).

In this PR, I have restructured the recipe into multiple outputs including separating the static libraries and dev files from necessary run_exports (the shared objects). The method I am using is to "build everything, then split". Everything is built in the top-level section and installed to a staging directory. Then a custom python install script is used to selectively install the artifacts based on the name of each output.

My motivation for this PR is to reduce the size of artifacts in my packages dependency trees starting from packages with the largest artifacts to the smallest.

#### Checklist for multi-output transition

- [x] Compare info/has_prefix for changes
- [x] Compare info/files for changes
- [x] Choose package names to prevent breaks of existing builds
