### PR TITLE
Fix static library names

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -24,4 +24,4 @@ if errorlevel 1 exit 1
 
 move %LIBRARY_LIB%\libcairo.a %LIBRARY_LIB%\cairo-static.lib
 move %LIBRARY_LIB%\libcairo-gobject.a %LIBRARY_LIB%\cairo-gobject-static.lib
-move %LIBRARY_LIB%\libcairo-script-intepreter.a %LIBRARY_LIB%\cairo-script-interpreter-static.lib
+move %LIBRARY_LIB%\libcairo-script-interpreter.a %LIBRARY_LIB%\cairo-script-interpreter-static.lib

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -22,3 +22,6 @@ if errorlevel 1 exit 1
 ninja -C builddir install -j %CPU_COUNT%
 if errorlevel 1 exit 1
 
+move %LIBRARY_LIB%\libcairo.a %LIBRARY_LIB%\cairo-static.lib
+move %LIBRARY_LIB%\libcairo-gobject.a %LIBRARY_LIB%\cairo-gobject-static.lib
+move %LIBRARY_LIB%\libcairo-script-intepreter.a %LIBRARY_LIB%\cairo-script-interpreter-static.lib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - windows-soversion-continuity.patch  # [win]
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage('cairo') }}
 
@@ -79,7 +79,7 @@ test:
     - test -f $PREFIX/lib/lib{{ each_cairo_lib }}.so                  # [linux]
     - if not exist %LIBRARY_BIN%\{{ each_cairo_lib }}.dll exit /b 1   # [win]
     - if not exist %LIBRARY_LIB%\{{ each_cairo_lib }}.lib exit /b 1   # [win]
-    - if not exist %LIBRARY_LIB%\lib{{ each_cairo_lib }}.a exit /b 1  # [win]
+    - if not exist %LIBRARY_LIB%\{{ each_cairo_lib }}-static.lib exit /b 1  # [win]
     {% endfor %}
 
     # Check pkg-config files.


### PR DESCRIPTION
With the new meson setup the libraries are named

  libcairo.a and cairo.lib

for the static library and import library.
However, when using mingw-w64, libcairo.a has higher priority over cairo.lib

This commit changes the libraries to pre-meson names

  cairo-static.lib and cairo.lib
  
cc @mbargull 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
