### PR TITLE
Enable even_odd_versions in bot configuration

### DIFF
--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.13'
+- '11.0'
 c_compiler:
 - clang
 c_compiler_version:
@@ -9,7 +9,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.13'
+- '11.0'
 cairo:
 - '1'
 channel_sources:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ stages:
   jobs:
     - job: Skip
       pool:
-        vmImage: 'ubuntu-22.04'
+        vmImage: 'ubuntu-latest'
       variables:
         DECODE_PERCENTS: 'false'
         RET: 'true'

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -13,3 +13,6 @@ provider:
   linux_ppc64le: default
   win: azure
 test: native_and_emulated
+bot:
+  version_updates:
+    even_odd_versions: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,15 +60,24 @@ test:
     # Verify libraries. Note that on Windows, we patch Cairo's build system to
     # produce DLL names like `cairo.dll` rather than `cairo-2.dll` to maintain
     # continuity with binaries shipped before the switch to Meson.
-    {% set cairo_libs = ["cairo", "cairo-gobject", "cairo-script-interpreter"] %}
-    {% for each_cairo_lib in cairo_libs %}
-    - test -f $PREFIX/lib/lib{{ each_cairo_lib }}.a                   # [not win]
-    - test -f $PREFIX/lib/lib{{ each_cairo_lib }}.dylib               # [osx]
-    - test -f $PREFIX/lib/lib{{ each_cairo_lib }}.so                  # [linux]
-    - if not exist %LIBRARY_BIN%\{{ each_cairo_lib }}.dll exit /b 1   # [win]
-    - if not exist %LIBRARY_LIB%\{{ each_cairo_lib }}.lib exit /b 1   # [win]
-    - if not exist %LIBRARY_LIB%\{{ each_cairo_lib }}-static.lib exit /b 1  # [win]
-    {% endfor %}
+    - test -f $PREFIX/lib/libcairo.a                   # [not win]
+    - test -f $PREFIX/lib/libcairo.dylib               # [osx]
+    - test -f $PREFIX/lib/libcairo.so                  # [linux]
+    - if not exist %LIBRARY_BIN%\cairo.dll exit /b 1   # [win]
+    - if not exist %LIBRARY_LIB%\cairo.lib exit /b 1   # [win]
+    - if not exist %LIBRARY_LIB%\cairo-static.lib exit /b 1  # [win]
+    - test -f $PREFIX/lib/libcairo-gobject.a                   # [not win]
+    - test -f $PREFIX/lib/libcairo-gobject.dylib               # [osx]
+    - test -f $PREFIX/lib/libcairo-gobject.so                  # [linux]
+    - if not exist %LIBRARY_BIN%\cairo-gobject.dll exit /b 1   # [win]
+    - if not exist %LIBRARY_LIB%\cairo-gobject.lib exit /b 1   # [win]
+    - if not exist %LIBRARY_LIB%\cairo-gobject-static.lib exit /b 1  # [win]
+    - test -f $PREFIX/lib/libcairo-script-interpreter.a                   # [not win]
+    - test -f $PREFIX/lib/libcairo-script-interpreter.dylib               # [osx]
+    - test -f $PREFIX/lib/libcairo-script-interpreter.so                  # [linux]
+    - if not exist %LIBRARY_BIN%\cairo-script-interpreter.dll exit /b 1   # [win]
+    - if not exist %LIBRARY_LIB%\cairo-script-interpreter.lib exit /b 1   # [win]
+    - if not exist %LIBRARY_LIB%\cairo-script-interpreter-static.lib exit /b 1  # [win]
 
     # Check pkg-config files.
     - test -f $PREFIX/lib/pkgconfig/cairo-quartz.pc                  # [osx]
@@ -92,7 +101,7 @@ about:
   home: http://cairographics.org/
   dev_url: https://gitlab.freedesktop.org/cairo/cairo
   doc_url: https://www.cairographics.org/documentation/
-  license: LGPL-2.1-only or MPL-1.1
+  license: LGPL-2.1-only OR MPL-1.1
   license_file:
     - COPYING
     - COPYING-LGPL-2.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,6 +48,7 @@ test:
     # The packages are below are
     # needed for the pkg-config invocations below
     - expat
+    - freetype
     - glib
     - zlib
     - xorg-xorgproto        # [linux]


### PR DESCRIPTION
This PR enables the `even_odd_versions` setting in the bot section of conda-forge.yml to prevent automated updates to unstable versions.

I also fixed a lint error for conda-recipe-manager by expanding the jinja loop for library names and added freetype to the test dependencies to fix a freetype2 pkg-config not found error.